### PR TITLE
Fixes for 1.9.2

### DIFF
--- a/lib/kestrel/client/stats_helper.rb
+++ b/lib/kestrel/client/stats_helper.rb
@@ -69,9 +69,9 @@ module Kestrel::Client::StatsHelper
 
   def deserialize_stat_value(value)
     case value
-    when /^\d+\.\d+$/:
+    when /^\d+\.\d+$/
         value.to_f
-    when /^\d+$/:
+    when /^\d+$/
         value.to_i
     else
       value

--- a/lib/kestrel/client/unmarshal.rb
+++ b/lib/kestrel/client/unmarshal.rb
@@ -11,11 +11,21 @@ module Kestrel
           response
         end
       end
-
-      def is_marshaled?(object)
-        object.to_s[0] == Marshal::MAJOR_VERSION && object.to_s[1] == Marshal::MINOR_VERSION
-      rescue Exception
-        false
+      
+      if RUBY_VERSION.respond_to?(:getbyte)
+        def is_marshaled?(object)
+          o = object.to_s
+          o.getbyte(0) == Marshal::MAJOR_VERSION && o.getbyte(1) == Marshal::MINOR_VERSION
+        rescue Exception
+          false
+        end
+      else
+        def is_marshaled?(object)
+          o = object.to_s
+          o[0] == Marshal::MAJOR_VERSION && o[1] == Marshal::MINOR_VERSION
+        rescue Exception
+          false
+        end
       end
     end
   end

--- a/spec/kestrel_benchmark.rb
+++ b/spec/kestrel_benchmark.rb
@@ -20,7 +20,7 @@ describe Kestrel::Client do
       x.report("set:") { for i in 1..times; @kestrel.set(@queue, @value); end }
       x.report("get:") { for i in 1..times; @kestrel.get(@queue); end }
       x.report("set (raw):") { for i in 1..times; @kestrel.set(@queue, @raw_value, 0, true); end }
-      x.report("get (raw):") { for i in 1..times; @kestrel.get(@queue, true); end }
+      x.report("get (raw):") { for i in 1..times; @kestrel.get(@queue, :raw => true); end }
     end
   end
 end


### PR DESCRIPTION
Hi,

while evaluating kestrel-client, I found that it had some minor issues with Ruby 1.9.2 which I fixed right along :).

I also took the liberty to fix one bug in your benchmark as well as eliminating the double "to_s" call in is_marshalled?

Regards,
Florian
